### PR TITLE
73: ignore userdata to avoid crash

### DIFF
--- a/vudu/vudubrowser.lua
+++ b/vudu/vudubrowser.lua
@@ -69,7 +69,8 @@ function vd.browser.bakeTable(t, context, list, depth)
   depth = depth or 0
   
   --Associative segment of table
-  for i, v in pairs(t) do if not vd.browser.ignore[context .. i] then
+  for i, v in pairs(t) do
+    if type(i)~="userdata" and not vd.browser.ignore[context..i] then -- igonre userdata to avoid crash
     local typ = type(v)
     if type(i) == "number" then
       local typ = type(v)


### PR DESCRIPTION
when I is userdata it can't concat with the context. Adding "userdata" to ignore list can't fix it.